### PR TITLE
deploy setting

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -15,7 +15,7 @@ worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port ENV.fetch("PORT") { 3000 }
+# port ENV.fetch("PORT") { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 #


### PR DESCRIPTION
port ENV.fetch("PORT", 3000)をコメントアウトせずデプロイを行うと、こちらを認識してしまい、うまく動作しないことがあるそう.
